### PR TITLE
Add camel-cased "OmniSharp" as C# LSP server

### DIFF
--- a/eglot.el
+++ b/eglot.el
@@ -325,6 +325,7 @@ automatically)."
     ((csharp-mode csharp-ts-mode)
      . ,(eglot-alternatives
          '(("omnisharp" "-lsp")
+           ("OmniSharp" "-lsp")
            ("csharp-ls"))))
     (purescript-mode . ("purescript-language-server" "--stdio"))
     ((perl-mode cperl-mode)


### PR DESCRIPTION
Some distributions provide a "OmniSharp" binary and no "omnisharp". This is
for example the case for Nixpkgs:
https://github.com/NixOS/nixpkgs/blob/9f023565a4ecb13a6863f72c05e598c801300b9e/pkgs/by-name/om/omnisharp-roslyn/package.nix#L121